### PR TITLE
Add tekton build args for BASE_BRANCH

### DIFF
--- a/.tekton/lighthouse-agent-devel-pull-request.yaml
+++ b/.tekton/lighthouse-agent-devel-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: package/Dockerfile.lighthouse-agent
+  - name: build-args-file
+    value: .tekton/lighthouse-agent-devel.args
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/lighthouse-agent-devel-push.yaml
+++ b/.tekton/lighthouse-agent-devel-push.yaml
@@ -29,6 +29,8 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: package/Dockerfile.lighthouse-agent
+  - name: build-args-file
+    value: .tekton/lighthouse-agent-devel.args
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/lighthouse-agent-devel.args
+++ b/.tekton/lighthouse-agent-devel.args
@@ -1,0 +1,1 @@
+BASE_BRANCH=devel


### PR DESCRIPTION
Fix build issue where BASE_BRANCH in the Dockerfile is missing. This is passed to buildah in our main builds by our .dapper scripting.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
